### PR TITLE
Fixing slf4j error at runtime

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -8,3 +8,5 @@ libraryDependencies ++= Seq(
   "org.http4s" %% "http4s-dsl"         % "$http4s_version$",
   "org.http4s" %% "http4s-argonaut"    % "$http4s_version$"
 )
+
+libraryDependencies += "org.slf4j" % "slf4j-simple" % "1.6.4"


### PR DESCRIPTION
This should fix the `SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".` error at runtime that was preventing the example server from loading.