### PR TITLE
Set stable versions of scala and http4s

### DIFF
--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -2,6 +2,5 @@ name = http4s quickstart
 organization = com.example
 package = $organization$.$name;format="norm,word"$
 
-scala_version = maven(org.scala-lang, scala-dist)
-
-http4s_version = 0.15.9a
+scala_version = 2.12.2
+http4s_version = 0.15.11a


### PR DESCRIPTION
sbt still can't use the `stable` modifier, so we'll have to keep it up to date ourselves for a bit longer.

The 0.17 branch needs this treatment, too.