### PR TITLE
Update Giter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ boot/
 lib_managed/
 src_managed/
 project/plugins/project/
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ script:
 
   ## Tricks to avoid unnecessary cache updates
   - find $HOME/.sbt -name "*.lock" | xargs rm
-  - find $HOME/.ivy2 -ma,e "ivydata-*.properties" | xargs rm
+  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: scala
+
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/
+
+jdk:
+  - oraclejdk8
+
+script:
+  ## This runs the template with the default parameters, and runs test within the templated app.
+  - sbt g8Test
+
+  ## Tricks to avoid unnecessary cache updates
+  - find $HOME/.sbt -name "*.lock" | xargs rm
+  - find $HOME/.ivy2 -ma,e "ivydata-*.properties" | xargs rm

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Generate an http4s service on the blaze backend with Circe.
 
 1. [Install sbt](http://www.scala-sbt.org/0.13/docs/Setup.html)
-2. sbt -sbt-version 0.13.13 new http4s/http4s.g8
+2. sbt -sbt-version 0.13.16 new http4s/http4s.g8
 3. `cd $THE_NAME_YOU_GAVE_IT`
 4. `sbt run`
 5. `curl http://localhost:8080/hello/$USER`

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,12 @@
-resolvers += Resolver.url("typesafe", url("http://repo.typesafe.com/typesafe/ivy-releases/"))(Resolver.ivyStylePatterns)
-
-scriptedBufferLog := false
-
-scriptedLaunchOpts ++= sys.process.javaVmArguments.filter(
-  a => Seq("-Xmx", "-Xms", "-XX", "-Dsbt.log.noformat").exists(a.startsWith)
-)
+// This build is for this Giter8 template.
+// To test the template run `g8` or `g8Test` from the sbt session.
+// See http://www.foundweekends.org/giter8/testing.html#Using+the+Giter8Plugin for more details.
+lazy val root = project.in(file("."))
+  .settings(
+    name := "http4s-g8",
+    test in Test := {
+      val _ = (g8Test in Test).toTask("").value
+    },
+    scriptedLaunchOpts ++= List("-Xms1024m", "-Xmx1024m", "-XX:ReservedCodeCacheSize=128m", "-Xss2m", "-Dfile.encoding=UTF-8"),
+    resolvers += Resolver.url("typesafe", url("http://repo.typesafe.com/typesafe/ivy-releases/"))(Resolver.ivyStylePatterns)
+  )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.16

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.foundweekends.giter8" % "sbt-giter8" % "0.7.1")
+addSbtPlugin("org.foundweekends.giter8" % "sbt-giter8" % "0.9.0")

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -4,10 +4,11 @@ version := "0.0.1-SNAPSHOT"
 scalaVersion := "$scala_version$"
 
 val Http4sVersion = "$http4s_version$"
+val LogbackVersion = "$logback_version$"
 
 libraryDependencies ++= Seq(
  "org.http4s"     %% "http4s-blaze-server" % Http4sVersion,
  "org.http4s"     %% "http4s-circe"        % Http4sVersion,
  "org.http4s"     %% "http4s-dsl"          % Http4sVersion,
- "ch.qos.logback" %  "logback-classic"     % "1.2.1"
+ "ch.qos.logback" %  "logback-classic"     % LogbackVersion
 )

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -2,6 +2,8 @@ name = http4s quickstart
 organization = com.example
 package = $organization$.$name;format="norm,word"$
 
-scala_version = 2.12.3
-http4s_version = 0.17.0-RC1
+scala_version = maven(org.scala-lang, scala-library, stable)
+http4s_version = maven(org.http4s, http4s-blaze-server_2.12)
+logback_version = maven(ch.qos.logback, logback-classic, stable)
+
 

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -3,6 +3,7 @@ organization = com.example
 package = $organization$.$name;format="norm,word"$
 
 scala_version = maven(org.scala-lang, scala-library, stable)
+sbt_version = maven(org.scala-sbt, sbt, stable)
 http4s_version = maven(org.http4s, http4s-blaze-server_2.12)
 logback_version = maven(ch.qos.logback, logback-classic, stable)
 

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.16

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=$sbt_version$


### PR DESCRIPTION
Giter Plugin is not 1.0 compatible. Other versions are all automatically handled. This is currently the newest. It now also has a stable so this can move to mainline when 0.17 is officially released, but may break with 0.18.0-M1 which may take precendence. Even perhaps putting a travis cron on this to alert us if master breaks.

We will need to turn on travis on this repo, which I don't have access for.

[Suceeding Build](https://travis-ci.org/ChristopherDavenport/http4s.g8/builds/267800563)