### PR TITLE
Enable partial unification

### DIFF
--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.0")


### PR DESCRIPTION
I did the minimal thing that gets apps working, even though I think sbt-tpolecat is the better set of defaults.  The main thing holding me back from the latter is not wanting to then go back and remove `-Xcheckinit`.
