### PR TITLE
Port to HttpRoutes

### DIFF
--- a/src/main/g8/src/main/scala/$package__packaged$/HelloWorldRoutes.scala
+++ b/src/main/g8/src/main/scala/$package__packaged$/HelloWorldRoutes.scala
@@ -6,7 +6,7 @@ import org.http4s.HttpRoutes
 import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
 
-class HelloWorldService[F[_]: Sync] extends Http4sDsl[F] {
+class HelloWorldRoutes[F[_]: Sync] extends Http4sDsl[F] {
   val routes: HttpRoutes[F] =
     HttpRoutes.of[F] {
       case GET -> Root / "hello" / name =>

--- a/src/main/g8/src/main/scala/$package__packaged$/HelloWorldServer.scala
+++ b/src/main/g8/src/main/scala/$package__packaged$/HelloWorldServer.scala
@@ -10,11 +10,11 @@ object HelloWorldServer extends IOApp {
 }
 
 object ServerStream {
-  def helloWorldService[F[_]: Effect] = new HelloWorldService[F].routes
+  def helloWorldRoutes[F[_]: Effect] = new HelloWorldRoutes[F].routes
 
   def stream[F[_]: ConcurrentEffect] =
     BlazeBuilder[F]
       .bindHttp(8080, "0.0.0.0")
-      .mountService(helloWorldService, "/")
+      .mountService(helloWorldRoutes, "/")
       .serve
 }

--- a/src/main/g8/src/main/scala/$package__packaged$/HelloWorldServer.scala
+++ b/src/main/g8/src/main/scala/$package__packaged$/HelloWorldServer.scala
@@ -10,7 +10,7 @@ object HelloWorldServer extends IOApp {
 }
 
 object ServerStream {
-  def helloWorldService[F[_]: Effect] = new HelloWorldService[F].service
+  def helloWorldService[F[_]: Effect] = new HelloWorldService[F].routes
 
   def stream[F[_]: ConcurrentEffect] =
     BlazeBuilder[F]

--- a/src/main/g8/src/main/scala/$package__packaged$/HelloWorldService.scala
+++ b/src/main/g8/src/main/scala/$package__packaged$/HelloWorldService.scala
@@ -1,17 +1,15 @@
 package $package$
 
-import cats.effect.Effect
+import cats.effect.Sync
 import io.circe.Json
-import org.http4s.HttpService
+import org.http4s.HttpRoutes
 import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
 
-class HelloWorldService[F[_]: Effect] extends Http4sDsl[F] {
-
-  val service: HttpService[F] = {
-    HttpService[F] {
+class HelloWorldService[F[_]: Sync] extends Http4sDsl[F] {
+  val routes: HttpRoutes[F] =
+    HttpRoutes.of[F] {
       case GET -> Root / "hello" / name =>
         Ok(Json.obj("message" -> Json.fromString(s"Hello, \${name}")))
     }
-  }
 }

--- a/src/main/g8/src/test/scala/$package__packaged$/HelloWorldSpec.scala
+++ b/src/main/g8/src/test/scala/$package__packaged$/HelloWorldSpec.scala
@@ -18,7 +18,7 @@ class HelloWorldSpec extends org.specs2.mutable.Specification {
 
   private[this] val retHelloWorld: Response[IO] = {
     val getHW = Request[IO](Method.GET, Uri.uri("/hello/world"))
-    new HelloWorldService[IO].service.orNotFound(getHW).unsafeRunSync()
+    new HelloWorldService[IO].routes.orNotFound(getHW).unsafeRunSync()
   }
 
   private[this] def uriReturns200(): MatchResult[Status] =

--- a/src/main/g8/src/test/scala/$package__packaged$/HelloWorldSpec.scala
+++ b/src/main/g8/src/test/scala/$package__packaged$/HelloWorldSpec.scala
@@ -18,7 +18,7 @@ class HelloWorldSpec extends org.specs2.mutable.Specification {
 
   private[this] val retHelloWorld: Response[IO] = {
     val getHW = Request[IO](Method.GET, Uri.uri("/hello/world"))
-    new HelloWorldService[IO].routes.orNotFound(getHW).unsafeRunSync()
+    new HelloWorldRoutes[IO].routes.orNotFound(getHW).unsafeRunSync()
   }
 
   private[this] def uriReturns200(): MatchResult[Status] =


### PR DESCRIPTION
This eliminates the deprecated calls in the 0.19 template.