### PR TITLE
Update to 0.19.0-M2 and sbt 1.2.1.

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -17,3 +17,11 @@ lazy val root = (project in file("."))
     )
   )
 
+scalacOptions ++= Seq(
+  "-deprecation",
+  "-encoding", "UTF-8",
+  "-language:higherKinds",
+  "-language:postfixOps",
+  "-feature",
+  "-Ypartial-unification",
+)

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -9,7 +9,7 @@ package = $organization$.$name;format="norm,word"$
 #logback_version = maven(ch.qos.logback, logback-classic, stable)
 
 scala_version = 2.12.6
-sbt_version = 1.1.6
-http4s_version = 0.19.0-M1
+sbt_version = 1.2.1
+http4s_version = 0.19.0-M2
 logback_version = 1.2.3
 specs2_version = 4.2.0

--- a/src/main/g8/src/main/scala/$package__packaged$/HelloWorldServer.scala
+++ b/src/main/g8/src/main/scala/$package__packaged$/HelloWorldServer.scala
@@ -2,17 +2,18 @@ package $package$
 
 import cats.effect.{ConcurrentEffect, Effect, ExitCode, IO, IOApp}
 import cats.implicits._
+import org.http4s.HttpRoutes
 import org.http4s.server.blaze.BlazeBuilder
 
 object HelloWorldServer extends IOApp {
-  def run(args: List[String]) =
+  def run(args: List[String]): IO[ExitCode] =
     ServerStream.stream[IO].compile.drain.as(ExitCode.Success)
 }
 
 object ServerStream {
-  def helloWorldRoutes[F[_]: Effect] = new HelloWorldRoutes[F].routes
+  def helloWorldRoutes[F[_]: Effect]: HttpRoutes[F] = new HelloWorldRoutes[F].routes
 
-  def stream[F[_]: ConcurrentEffect] =
+  def stream[F[_]: ConcurrentEffect]: fs2.Stream[F, ExitCode]=
     BlazeBuilder[F]
       .bindHttp(8080, "0.0.0.0")
       .mountService(helloWorldRoutes, "/")


### PR DESCRIPTION
 We've also added some useful `scalacOptions` to the build. In particular `-Ypartial-unification` is pretty necessary to use `cats`.

In addition, we've added explicit return types to the functions in `HelloWorldServer` to make it a bit friendlier for newcomers to understand what types are in use.

We did these changes at the Syntactic Sugar meetup in London.

Angelos Michos (@ang-mic) and Doug Clinton (@dougc)