### PR TITLE
Move kind-projector plugin to where it works

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -14,6 +14,7 @@ lazy val root = (project in file("."))
       "org.http4s"      %% "http4s-dsl"          % Http4sVersion,
       "org.specs2"     %% "specs2-core"          % Specs2Version % "test",
       "ch.qos.logback"  %  "logback-classic"     % LogbackVersion
-    )
+    ),
+    addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.6")
   )
 

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,4 +1,3 @@
 addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.0")
 //addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.3")
-addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.6")
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")


### PR DESCRIPTION
Tested only manually, because the template doesn't need kind projection.  We're just trying to include all batteries.