### PR TITLE
Downgrade specs2 to 4.1.0

### DIFF
--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -12,4 +12,4 @@ scala_version = 2.12.6
 sbt_version = 1.2.1
 http4s_version = 0.18.18
 logback_version = 1.2.3
-specs2_version = 4.2.0
+specs2_version = 4.1.0


### PR DESCRIPTION
This is the version that's compatible with http4s-testing, cats-laws, cats-effect-laws, et al.  Until the [scalacheck quagmire](https://github.com/typelevel/cats/pull/2312) is resolved, I don't think this upgrade makes a lot of sense in this ecosystem.