### PR TITLE
Add svm-subs

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -18,7 +18,7 @@ lazy val root = (project in file("."))
       "org.specs2"      %% "specs2-core"         % Specs2Version % "test",
       "ch.qos.logback"  %  "logback-classic"     % LogbackVersion,
       $if(graal_native_image.truthy)$
-      "org.scalameta"   %% "svm-subs"            % "20.2.0"      % "compile-internal"
+      "org.scalameta"   %% "svm-subs"            % "20.2.0"
       $endif$
     ),
     addCompilerPlugin("org.typelevel" %% "kind-projector"     % "0.10.3"),

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -16,7 +16,10 @@ lazy val root = (project in file("."))
       "org.http4s"      %% "http4s-dsl"          % Http4sVersion,
       "io.circe"        %% "circe-generic"       % CirceVersion,
       "org.specs2"      %% "specs2-core"         % Specs2Version % "test",
-      "ch.qos.logback"  %  "logback-classic"     % LogbackVersion
+      "ch.qos.logback"  %  "logback-classic"     % LogbackVersion,
+      $if(graal_native_image.truthy)$
+      "org.scalameta"   %% "svm-subs"            % "20.2.0"      % "compile-internal"
+      $endif$
     ),
     addCompilerPlugin("org.typelevel" %% "kind-projector"     % "0.10.3"),
     addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.1")


### PR DESCRIPTION
Based on [this idea](https://github.com/scala/bug/issues/11634#issuecomment-683253451). I'm still not clear what made all the native builds suddenly bitrot, and I don't know how the sbt-native-image plugin interferes with the static instructions we have.  I don't have any idea what I'm doing.