### PR TITLE
Remove redundant space from default.properties

### DIFF
--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -16,5 +16,5 @@ logback_version = 1.2.3
 specs2_version = 4.10.5
 # graal_vm_specific
 graal_native_image = true
-is_linux_build = false 
+is_linux_build = false
 scala_assembly_target = scala-2.13


### PR DESCRIPTION
It causes wrong rendering (`is_linux_build`):

![image](https://user-images.githubusercontent.com/11317222/97925444-115d5400-1d6a-11eb-9cb2-1c1440bc9791.png)
