### PR TITLE
Enable, upgrade sbt-tpolecat

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -24,12 +24,3 @@ lazy val root = (project in file("."))
     addCompilerPlugin("org.typelevel" %% "kind-projector"     % "0.10.3"),
     addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.1")
   )
-
-scalacOptions ++= Seq(
-  "-deprecation",
-  "-encoding", "UTF-8",
-  "-language:higherKinds",
-  "-language:postfixOps",
-  "-feature",
-  "-Xfatal-warnings",
-)

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,3 +1,3 @@
-//addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.3")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.14")
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")

--- a/src/main/g8/src/main/scala/$package__packaged$/$name__Camel$Server.scala
+++ b/src/main/g8/src/main/scala/$package__packaged$/$name__Camel$Server.scala
@@ -1,6 +1,6 @@
 package $package$
 
-import cats.effect.{ConcurrentEffect, ContextShift, Timer}
+import cats.effect.{ConcurrentEffect, Timer}
 import cats.implicits._
 import fs2.Stream
 import org.http4s.client.blaze.BlazeClientBuilder
@@ -11,7 +11,7 @@ import scala.concurrent.ExecutionContext.global
 
 object $name;format="Camel"$Server {
 
-  def stream[F[_]: ConcurrentEffect](implicit T: Timer[F], C: ContextShift[F]): Stream[F, Nothing] = {
+  def stream[F[_]: ConcurrentEffect](implicit T: Timer[F]): Stream[F, Nothing] = {
     for {
       client <- BlazeClientBuilder[F](global).stream
       helloWorldAlg = HelloWorld.impl[F]

--- a/src/main/g8/src/main/scala/$package__packaged$/Jokes.scala
+++ b/src/main/g8/src/main/scala/$package__packaged$/Jokes.scala
@@ -3,15 +3,14 @@ package $package$
 import cats.Applicative
 import cats.effect.Sync
 import cats.implicits._
-import io.circe.{Encoder, Decoder, Json, HCursor}
+import io.circe.{Encoder, Decoder}
 import io.circe.generic.semiauto._
 import org.http4s._
 import org.http4s.implicits._
-import org.http4s.{EntityDecoder, EntityEncoder, Method, Uri, Request}
 import org.http4s.client.Client
 import org.http4s.client.dsl.Http4sClientDsl
-import org.http4s.Method._
 import org.http4s.circe._
+import org.http4s.Method._
 
 trait Jokes[F[_]]{
   def get: F[Jokes.Joke]

--- a/src/main/g8/src/main/scala/$package__packaged$/Main.scala
+++ b/src/main/g8/src/main/scala/$package__packaged$/Main.scala
@@ -1,7 +1,6 @@
 package $package$
 
 import cats.effect.{ExitCode, IO, IOApp}
-import cats.implicits._
 
 object Main extends IOApp {
   def run(args: List[String]) =


### PR DESCRIPTION
We hesitated to enable this by default, and I'm still on the fence about that.  But we've made a mess without it on.

If we don't do this, we should minimally upgrade the commented version, or remove it.

Fixes #103. Fixes #175.

