### PR TITLE
Mark logback as a runtime dependecy

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -18,7 +18,7 @@ lazy val root = (project in file("."))
       "io.circe"        %% "circe-generic"       % CirceVersion,
       "org.scalameta"   %% "munit"               % MunitVersion           % Test,
       "org.typelevel"   %% "munit-cats-effect-3" % MunitCatsEffectVersion % Test,
-      "ch.qos.logback"  %  "logback-classic"     % LogbackVersion,
+      "ch.qos.logback"  %  "logback-classic"     % LogbackVersion         % Runtime,
       $if(graal_native_image.truthy)$
       "org.scalameta"   %% "svm-subs"            % "20.2.0"
       $endif$


### PR DESCRIPTION
Logback is not required for compilation and so should be marked as a runtime-only dependency