### PR TITLE
Cleanup unclear code in 0.23 template

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,8 @@
-Written in 2017 by 
+Written in 2017-2022 by 
 
 Christopher Davenport, chris@christopherdavenport.tech
 Ross A. Baker, ross@rossabaker.com
+Justin Reardon, me@jmreardon.com
 
 To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this template to the public domain worldwide.
 This template is distributed without any warranty. See <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/src/main/g8/src/main/scala/$package__packaged$/$name__Camel$Server.scala
+++ b/src/main/g8/src/main/scala/$package__packaged$/$name__Camel$Server.scala
@@ -1,9 +1,8 @@
 package $package$
 
-import cats.effect.{Async, Resource}
+import cats.effect.Async
 import cats.syntax.all._
 import com.comcast.ip4s._
-import fs2.Stream
 import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.implicits._
@@ -11,9 +10,9 @@ import org.http4s.server.middleware.Logger
 
 object $name;format="Camel"$Server {
 
-  def stream[F[_]: Async]: Stream[F, Nothing] = {
+  def run[F[_]: Async]: F[Nothing] = {
     for {
-      client <- Stream.resource(EmberClientBuilder.default[F].build)
+      client <- EmberClientBuilder.default[F].build
       helloWorldAlg = HelloWorld.impl[F]
       jokeAlg = Jokes.impl[F](client)
 
@@ -29,14 +28,12 @@ object $name;format="Camel"$Server {
       // With Middlewares in place
       finalHttpApp = Logger.httpApp(true, true)(httpApp)
 
-      exitCode <- Stream.resource(
+      _ <- 
         EmberServerBuilder.default[F]
           .withHost(ipv4"0.0.0.0")
           .withPort(port"8080")
           .withHttpApp(finalHttpApp)
-          .build >>
-        Resource.eval(Async[F].never)
-      )
-    } yield exitCode
-  }.drain
+          .build
+    } yield ()
+  }.useForever
 }

--- a/src/main/g8/src/main/scala/$package__packaged$/HelloWorld.scala
+++ b/src/main/g8/src/main/scala/$package__packaged$/HelloWorld.scala
@@ -11,8 +11,6 @@ trait HelloWorld[F[_]]{
 }
 
 object HelloWorld {
-  implicit def apply[F[_]](implicit ev: HelloWorld[F]): HelloWorld[F] = ev
-
   final case class Name(name: String) extends AnyVal
   /**
     * More generally you will want to decouple your edge representations from

--- a/src/main/g8/src/main/scala/$package__packaged$/Main.scala
+++ b/src/main/g8/src/main/scala/$package__packaged$/Main.scala
@@ -1,8 +1,7 @@
 package $package$
 
-import cats.effect.{ExitCode, IO, IOApp}
+import cats.effect.{IO, IOApp}
 
-object Main extends IOApp {
-  def run(args: List[String]) =
-    $name;format="Camel"$Server.stream[IO].compile.drain.as(ExitCode.Success)
+object Main extends IOApp.Simple {
+  val run = $name;format="Camel"$Server.run[IO]
 }


### PR DESCRIPTION
Port fixes to 1.0 template in PR #294. This PRis  cherry-picks with no changes, so I have left the copyright year in 2022.

- #278 Use F directly instead of `Stream`
- #108 Remove unused implicit