### PR TITLE
Update http4s to 0.23.19 for 0.23-scala3

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.8.3

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("org.foundweekends.giter8" % "sbt-giter8" % "0.16.2")
-addSbtPlugin("org.typelevel" % "sbt-typelevel-github-actions" % "0.4.20")
+addSbtPlugin("org.typelevel" % "sbt-typelevel-github-actions" % "0.4.21")

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -8,8 +8,8 @@ package = $organization$.$name;format="norm,word"$
 #http4s_version = maven(org.http4s, http4s-blaze-server_2.12, stable)
 #logback_version = maven(ch.qos.logback, logback-classic, stable)
 
-sbt_version = 1.8.2
-http4s_version = 0.23.18
+sbt_version = 1.8.3
+http4s_version = 0.23.19
 logback_version = 1.4.7
 munit_version = 0.7.29
 munit_cats_effect_version = 1.0.7

--- a/src/main/g8/src/main/scala/$package__packaged$/$name__Camel$Routes.scala
+++ b/src/main/g8/src/main/scala/$package__packaged$/$name__Camel$Routes.scala
@@ -1,7 +1,7 @@
 package $package$
 
 import cats.effect.Sync
-import cats.implicits._
+import cats.syntax.all.*
 import org.http4s.HttpRoutes
 import org.http4s.dsl.Http4sDsl
 
@@ -9,7 +9,7 @@ object $name;format="Camel"$Routes:
 
   def jokeRoutes[F[_]: Sync](J: Jokes[F]): HttpRoutes[F] =
     val dsl = new Http4sDsl[F]{}
-    import dsl._
+    import dsl.*
     HttpRoutes.of[F] {
       case GET -> Root / "joke" =>
         for {
@@ -20,7 +20,7 @@ object $name;format="Camel"$Routes:
 
   def helloWorldRoutes[F[_]: Sync](H: HelloWorld[F]): HttpRoutes[F] =
     val dsl = new Http4sDsl[F]{}
-    import dsl._
+    import dsl.*
     HttpRoutes.of[F] {
       case GET -> Root / "hello" / name =>
         for {

--- a/src/main/g8/src/main/scala/$package__packaged$/$name__Camel$Server.scala
+++ b/src/main/g8/src/main/scala/$package__packaged$/$name__Camel$Server.scala
@@ -1,16 +1,17 @@
 package $package$
 
 import cats.effect.Async
-import cats.syntax.all._
-import com.comcast.ip4s._
+import cats.syntax.all.*
+import com.comcast.ip4s.*
+import fs2.io.net.Network
 import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.ember.server.EmberServerBuilder
-import org.http4s.implicits._
+import org.http4s.implicits.*
 import org.http4s.server.middleware.Logger
 
 object $name;format="Camel"$Server:
 
-  def run[F[_]: Async]: F[Nothing] = {
+  def run[F[_]: Async: Network]: F[Nothing] = {
     for {
       client <- EmberClientBuilder.default[F].build
       helloWorldAlg = HelloWorld.impl[F]

--- a/src/main/g8/src/main/scala/$package__packaged$/HelloWorld.scala
+++ b/src/main/g8/src/main/scala/$package__packaged$/HelloWorld.scala
@@ -1,10 +1,10 @@
 package $package$
 
 import cats.Applicative
-import cats.implicits._
+import cats.syntax.all.*
 import io.circe.{Encoder, Json}
 import org.http4s.EntityEncoder
-import org.http4s.circe._
+import org.http4s.circe.*
 
 trait HelloWorld[F[_]]:
   def hello(n: HelloWorld.Name): F[HelloWorld.Greeting]

--- a/src/main/g8/src/main/scala/$package__packaged$/Jokes.scala
+++ b/src/main/g8/src/main/scala/$package__packaged$/Jokes.scala
@@ -1,14 +1,14 @@
 package $package$
 
 import cats.effect.Concurrent
-import cats.implicits._
+import cats.syntax.all.*
 import io.circe.{Encoder, Decoder}
-import org.http4s._
-import org.http4s.implicits._
+import org.http4s.*
+import org.http4s.implicits.*
 import org.http4s.client.Client
 import org.http4s.client.dsl.Http4sClientDsl
-import org.http4s.circe._
-import org.http4s.Method._
+import org.http4s.circe.*
+import org.http4s.Method.*
 
 trait Jokes[F[_]]:
   def get: F[Jokes.Joke]
@@ -27,7 +27,7 @@ object Jokes:
 
   def impl[F[_]: Concurrent](C: Client[F]): Jokes[F] = new Jokes[F]:
     val dsl = new Http4sClientDsl[F]{}
-    import dsl._
+    import dsl.*
     def get: F[Jokes.Joke] = 
       C.expect[Joke](GET(uri"https://icanhazdadjoke.com/"))
         .adaptError{ case t => JokeError(t)} // Prevent Client Json Decoding Failure Leaking

--- a/src/main/g8/src/test/scala/$package__packaged$/HelloWorldSpec.scala
+++ b/src/main/g8/src/test/scala/$package__packaged$/HelloWorldSpec.scala
@@ -1,8 +1,8 @@
 package $package$
 
 import cats.effect.IO
-import org.http4s._
-import org.http4s.implicits._
+import org.http4s.*
+import org.http4s.implicits.*
 import munit.CatsEffectSuite
 
 class HelloWorldSpec extends CatsEffectSuite:


### PR DESCRIPTION
Bringing this up to date with http4s 0.23.19.

I also updated the import syntax and used `cats.syntax.all.*` instead of `cats.implicits.*`