### PR TITLE
Update default dependency versions and fix deprecation

### DIFF
--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -10,9 +10,9 @@ package = $organization$.$name;format="norm,word"$
 
 scala_version = 2.13.10
 sbt_version = 1.8.0
-http4s_version = 0.23.18
-circe_version = 0.14.3
-logback_version = 1.2.11
+http4s_version = 0.23.20
+circe_version = 0.14.5
+logback_version = 1.4.8
 munit_version = 0.7.29
 munit_cats_effect_version = 1.0.7
 # graal_vm_specific

--- a/src/main/g8/src/main/scala/$package__packaged$/$name__Camel$Server.scala
+++ b/src/main/g8/src/main/scala/$package__packaged$/$name__Camel$Server.scala
@@ -3,6 +3,7 @@ package $package$
 import cats.effect.Async
 import cats.syntax.all._
 import com.comcast.ip4s._
+import fs2.io.net.Network
 import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.implicits._
@@ -10,7 +11,7 @@ import org.http4s.server.middleware.Logger
 
 object $name;format="Camel"$Server {
 
-  def run[F[_]: Async]: F[Nothing] = {
+  def run[F[_]: Async: Network]: F[Nothing] = {
     for {
       client <- EmberClientBuilder.default[F].build
       helloWorldAlg = HelloWorld.impl[F]


### PR DESCRIPTION
Running this template with the most current version of http4s prints the following warning:
```
method implicitForAsync in trait NetworkLowPriority is deprecated (since 3.7.0): Add Network constraint or use forAsync
```

This pull request updates the defaults for the dependency versions and fixes the deprecation.