### PR TITLE
Downgrade logback to allow template to work with Java 8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ ThisBuild / githubWorkflowPublishTargetBranches := Seq.empty
 val Http4sVersion = "0.23.23"
 val CirceVersion = "0.14.5"
 val MunitVersion = "0.7.29"
-val LogbackVersion = "1.3.11"
+val LogbackVersion = "1.2.12"
 val MunitCatsEffectVersion = "1.0.7"
 
 lazy val root = project

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ ThisBuild / githubWorkflowPublishTargetBranches := Seq.empty
 val Http4sVersion = "0.23.23"
 val CirceVersion = "0.14.5"
 val MunitVersion = "0.7.29"
-val LogbackVersion = "1.4.11"
+val LogbackVersion = "1.3.11"
 val MunitCatsEffectVersion = "1.0.7"
 
 lazy val root = project

--- a/scala-steward.conf
+++ b/scala-steward.conf
@@ -1,0 +1,1 @@
+updates.pin  = [ { groupId = "ch.qos.logback", artifactId="logback-classic", version = "1.3." } ]

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,7 +1,7 @@
 val Http4sVersion = "0.23.23"
 val CirceVersion = "0.14.5"
 val MunitVersion = "0.7.29"
-val LogbackVersion = "1.4.11"
+val LogbackVersion = "1.3.11"
 val MunitCatsEffectVersion = "1.0.7"
 
 lazy val root = (project in file("."))

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,7 +1,7 @@
 val Http4sVersion = "0.23.23"
 val CirceVersion = "0.14.5"
 val MunitVersion = "0.7.29"
-val LogbackVersion = "1.3.11"
+val LogbackVersion = "1.2.12"
 val MunitCatsEffectVersion = "1.0.7"
 
 lazy val root = (project in file("."))


### PR DESCRIPTION
fixes #335 

Logback maintains two identical release lines for Java 11 and above and older ones. This PR downgrades to the one supporting Java 8.

The alternative to doing so would be to stop supporting Java 8 (it is out of normal support anyways). I would personally prefer the solution to unsupport Java 8 but am not sure if this is the right way to go. If this is preferable I am happy to update the documentation and the pipelines. 

Opinions?