### PR TITLE
Remove scala version from default.properties

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -9,7 +9,7 @@ lazy val root = (project in file("."))
     organization := "$organization$",
     name := "$name;format="norm"$",
     version := "0.0.1-SNAPSHOT",
-    scalaVersion := "$scala_version$",
+    scalaVersion := "2.13.15",
     libraryDependencies ++= Seq(
       "org.http4s"      %% "http4s-ember-server" % Http4sVersion,
       "org.http4s"      %% "http4s-ember-client" % Http4sVersion,

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,5 +1,3 @@
 name = quickstart
 organization = com.example
 package = $organization$.$name;format="norm,word"$
-
-scala_version = 2.13.15


### PR DESCRIPTION
Artifacts published with higher scala minor versions are not downwards compatible. Therefore I believe it does not make a lot of sense to configure the scala version on template generation.
Compare https://github.com/http4s/http4s.g8/actions/runs/11562204886/job/32182864793#step:9:120

~~Additionally I hope this allows the steward to update the version for us.~~ (Update: I think that won't work actually as this would need the top level sbt project upgraded to scala 2.13. That however makes sbt very angry because of the sbt-scripted plugin)
